### PR TITLE
Add simple Flask chat interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,38 @@ resp = client.responses.create(
 
 print(resp.output_text)
 ```
+
+## Simple Flask chat interface
+
+The repository also contains `chat_ui.py`, a minimal Flask web app that keeps
+conversation context while always providing the Fastmail MCP server to OpenAI.
+The application expects the following environment variables:
+
+- `BEARER_TOKEN` – the static token used by the MCP server
+- `FASTMAIL_API_KEY` – your Fastmail API token
+- `MCP_SERVER_URL` – URL of the MCP server (defaults to
+  `http://127.0.0.1:8000/mcp/`)
+- `OPENAI_API_KEY` – API key for OpenAI
+
+Launch the interface with:
+
+```bash
+export OPENAI_API_KEY=<OPENAI_API_KEY>
+export BEARER_TOKEN=<BEARER_TOKEN>
+export FASTMAIL_API_KEY=<FASTMAIL_API_KEY>
+python chat_ui.py
+```
+
+Open `http://127.0.0.1:5000` in your browser and start chatting. Use the
+**Clear** button to reset the conversation state.
+
+The chat app sends requests to OpenAI like so:
+
+```python
+resp = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=conversation,
+    tools=build_tools(),  # MCP configuration
+)
+assistant_text = resp.choices[0].message.content
+```

--- a/chat_ui.py
+++ b/chat_ui.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Simple Flask chat interface using OpenAI and the Fastmail MCP server."""
+
+import os
+from flask import Flask, request, render_template_string, session, redirect, url_for
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BEARER_TOKEN = os.getenv("BEARER_TOKEN")
+FASTMAIL_API_KEY = os.getenv("FASTMAIL_API_KEY")
+MCP_SERVER_URL = os.getenv("MCP_SERVER_URL", "http://127.0.0.1:8000/mcp/")
+
+if not BEARER_TOKEN or not FASTMAIL_API_KEY:
+    raise RuntimeError(
+        "BEARER_TOKEN and FASTMAIL_API_KEY environment variables are required"
+    )
+
+app = Flask(__name__)
+app.secret_key = os.getenv("FLASK_SECRET_KEY", "replace-this-secret")
+
+client = OpenAI()
+
+
+def build_tools() -> list[dict]:
+    """Return the tool configuration for the Fastmail MCP server."""
+    return [
+        {
+            "type": "mcp",
+            "server_label": "Email",
+            "server_url": MCP_SERVER_URL,
+            "require_approval": "never",
+            "headers": {
+                "Authorization": f"Bearer {BEARER_TOKEN}",
+                "fastmail-api-token": FASTMAIL_API_KEY,
+            },
+        }
+    ]
+
+
+HTML_TEMPLATE = """
+<!doctype html>
+<title>Fastmail Chat</title>
+<h1>Fastmail Chat</h1>
+<form method=post>
+    <input type=text name=message autofocus>
+    <button type=submit>Send</button>
+    <button type=submit name=clear value=1>Clear</button>
+</form>
+<ul>
+{% for m in conversation %}
+    <li><strong>{{ m.role }}:</strong> {{ m.content }}</li>
+{% endfor %}
+</ul>
+"""
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    if "conversation" not in session:
+        session["conversation"] = []
+
+    if request.method == "POST":
+        if request.form.get("clear"):
+            session["conversation"] = []
+            return redirect(url_for("index"))
+
+        user_message = request.form["message"]
+        conversation: list[dict] = session["conversation"]
+        conversation.append({"role": "user", "content": user_message})
+
+        resp = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=conversation,
+            tools=build_tools(),
+        )
+        assistant = resp.choices[0].message.content
+        conversation.append({"role": "assistant", "content": assistant})
+        session["conversation"] = conversation
+
+    return render_template_string(HTML_TEMPLATE, conversation=session["conversation"])
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,5 @@ typing-inspect==0.9.0
 typing-inspection==0.4.1
 urllib3==2.4.0
 uvicorn==0.34.3
+Flask==3.0.3
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- add `chat_ui.py` as a minimal Flask chat interface for the Fastmail MCP server
- include Flask and openai dependencies
- document how to use the chat interface

## Testing
- `python -m py_compile chat_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_6842e9c9f6708327990ecafceecaaa91