### PR TITLE
Exclude junk/deleted from keyword search

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The server implements the following tools:
   - `list_inbox_emails`: Lists the emails in the Inbox (id, sender, subject, and
     date). Accepts an `offset` for pagination.
   - `query_emails_by_keyword`: Searches for a keyword in the subject or body of
-    emails. Returns the total matches and a page of results, with an optional
-    `offset` parameter.
+    emails while ignoring messages flagged as junk or deleted. Returns the total
+    matches and a page of results, with an optional `offset` parameter.
   - `get_email_content`: Retrieves the content of an email given an id. HTML
     content is converted to text using
     [BeautifulSoup4](https://www.crummy.com/software/BeautifulSoup/).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The server implements the following tools:
   - `list_inbox_emails`: Lists the emails in the Inbox (id, sender, subject, and
     date). Accepts an `offset` for pagination.
   - `query_emails_by_keyword`: Searches for a keyword in the subject or body of
-    emails while ignoring messages flagged as junk or deleted. Returns the total
+    emails while ignoring junk and deleted messages. Returns the total
     matches and a page of results, with an optional `offset` parameter.
   - `get_email_content`: Retrieves the content of an email given an id. HTML
     content is converted to text using

--- a/fastmail.py
+++ b/fastmail.py
@@ -8,8 +8,10 @@ from jmapc import (
     Client,
     Comparator,
     EmailQueryFilterCondition,
+    EmailQueryFilterOperator,
     MailboxQueryFilterCondition,
     Ref,
+    Operator,
 )
 from jmapc.methods import (
     EmailGet,
@@ -190,10 +192,19 @@ def fastmail_query_emails_by_keyword(
     logger.debug("Querying emails for keyword '%s' (offset=%s)", keyword, offset)
     client = get_client(api_token)
 
+    compound_filter = EmailQueryFilterOperator(
+        operator=Operator.AND,
+        conditions=[
+            EmailQueryFilterCondition(not_keyword="$deleted"),
+            EmailQueryFilterCondition(not_keyword="$junk"),
+            EmailQueryFilterCondition(text=keyword),
+        ],
+    )
+
     results = client.request(
         [
             EmailQuery(
-                filter=EmailQueryFilterCondition(text=keyword),
+                filter=compound_filter,
                 sort=[Comparator(property="receivedAt", is_ascending=False)],
                 position=offset,
                 calculate_total=True,


### PR DESCRIPTION
## Summary
- filter out junk and deleted mail in `fastmail_query_emails_by_keyword`
- document new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684adddf535483279f536d022f7116de