### PR TITLE
Fix warnings in tests

### DIFF
--- a/tests/test_mcp_endpoints.py
+++ b/tests/test_mcp_endpoints.py
@@ -38,7 +38,9 @@ def call_tool(client: TestClient, name: str, args: dict | None = None, *, includ
     }
     if include_api_token:
         headers["fastmail-api-token"] = "api-token"
-    return client.post("/mcp/", data=json.dumps(message), headers=headers)
+    # httpx deprecated using `data` with raw JSON strings. Use `content` to
+    # avoid deprecation warnings when posting JSON payloads.
+    return client.post("/mcp/", content=json.dumps(message), headers=headers)
 
 
 def test_list_inbox_emails_endpoint():


### PR DESCRIPTION
## Summary
- silence httpx deprecation warnings in tests by using `content`
- tests still pass with no warnings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501f08e8508327a634ae8f592eb02b